### PR TITLE
Fix html.escape desc to reflect it's useless with double curly braces

### DIFF
--- a/content/docs/digging_deeper/helpers.md
+++ b/content/docs/digging_deeper/helpers.md
@@ -110,7 +110,7 @@ In the following example, the `<br />` tags will be not be escaped, however, the
 ```
 
 ## html.escape
-Escape HTML inside a string value. The double curly braces already escape the value, so use this method only when you are not using the three curly braces.
+Escape HTML inside a string value. The double curly braces already escape the value, so use this method only when you are using the triple curly braces.
 
 ```edge
 {{{ html.escape(post.content) }}}


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/edge-js/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

I didn't open one as it is really minor, will do if it's necessary.

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation Typo

### 📚 Description

There is a typo in the current description.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
